### PR TITLE
UdpListener code cleanup

### DIFF
--- a/TimberWinR/Inputs/UdpInputListener.cs
+++ b/TimberWinR/Inputs/UdpInputListener.cs
@@ -94,13 +94,13 @@ namespace TimberWinR.Inputs
                         lastMessage = data;
                         JObject json = JObject.Parse(data);
                         ProcessJson(json);
-                        _receivedMessages++;
+                        Interlocked.Increment(ref _receivedMessages);
                     }
                     catch (Exception ex)
                     {
                         LogManager.GetCurrentClassLogger().Warn("Bad JSON: {0}", lastMessage);
                         LogManager.GetCurrentClassLogger().Warn(ex);
-                        _parsedErrors++;
+                        Interlocked.Increment(ref _parsedErrors);
                     }
                 }
                 profile.Client.Close();

--- a/TimberWinR/Inputs/UdpInputListener.cs
+++ b/TimberWinR/Inputs/UdpInputListener.cs
@@ -55,9 +55,11 @@ namespace TimberWinR.Inputs
             _udpListenerV6 = new UdpClient(groupV6);
 
             _listenThreadV4 = new Thread(StartListener);
+            _listenThreadV4.Name = "UdpInputListener-v4";
             _listenThreadV4.Start(new ListenProfile { EndPoint = groupV4, Client = _udpListenerV4 });
 
             _listenThreadV6 = new Thread(StartListener);
+            _listenThreadV6.Name = "UdpInputListener-v6";
             _listenThreadV6.Start(new ListenProfile { EndPoint = groupV6, Client = _udpListenerV6 });
         }
 


### PR DESCRIPTION
Minor cleanup on the UdpListener class:
* Use a dedicated UDP client for IPv4 and IPv6 respectively
* C# naming conventions
* Moving variables to local scope if not required as member variables
* Await end of threads in shutdown method