### PR TITLE
Rolled Udp input listener support to ipv4 only.

### DIFF
--- a/TimberWinR.ServiceHost/Properties/AssemblyInfo.cs
+++ b/TimberWinR.ServiceHost/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.20.0")]
-[assembly: AssemblyFileVersion("1.3.20.0")]
+[assembly: AssemblyVersion("1.3.21.0")]
+[assembly: AssemblyFileVersion("1.3.21.0")]

--- a/TimberWinR/ReleaseNotes.md
+++ b/TimberWinR/ReleaseNotes.md
@@ -3,6 +3,9 @@
 A Native Windows to Redis/Elasticsearch Logstash Agent which runs as a service.
 
 Version / Date
+### 1.3.21.0 - 04/13/2015
+1. Rolled Udp listener support to V4 only, too many issues with dual mode sockets
+   and hosts file.  If we want to add this back, I will add a Udpv6 input.
 
 ### 1.3.20.0 - 04/03/2015
 1. A re-factoring of Logs and TailLogs to be more efficient and detect log rolling correctly,


### PR DESCRIPTION
There were too many issues requiring hosts file changes to support Udp ipv4 and ipv6 with a dual
mode socket, so I am rolling it back to ipv4 only.  @hardcodet @thoean please review.
