### PR TITLE
Release candidate 1.3.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ represented as a JSON Property or Array.
 1. [Redis](https://github.com/Cimpress-MCP/TimberWinR/blob/master/TimberWinR/mdocs/RedisOutput.md)
 2. [Elasticsearch](https://github.com/Cimpress-MCP/TimberWinR/blob/master/TimberWinR/mdocs/ElasticsearchOutput.md)
 3. [Stdout](https://github.com/Cimpress-MCP/TimberWinR/blob/master/TimberWinR/mdocs/StdoutOutput.md)
+4. [File](https://github.com/Cimpress-MCP/TimberWinR/blob/master/TimberWinR/mdocs/FileOutput.md)
 
 ## Sample Configuration
 TimberWinR reads a JSON configuration file, an example file is shown here:

--- a/TimberWinR.ServiceHost/Properties/AssemblyInfo.cs
+++ b/TimberWinR.ServiceHost/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.24.0")]
-[assembly: AssemblyFileVersion("1.3.24.0")]
+[assembly: AssemblyVersion("1.3.25.0")]
+[assembly: AssemblyFileVersion("1.3.25.0")]

--- a/TimberWinR.TestGenerator/TimberWinR.TestGenerator.csproj
+++ b/TimberWinR.TestGenerator/TimberWinR.TestGenerator.csproj
@@ -117,6 +117,15 @@
     <Content Include="test4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="test5-twconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="test5.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="results5.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TimberWinR\TimberWinR.csproj">

--- a/TimberWinR.TestGenerator/UdpTestGenerator.cs
+++ b/TimberWinR.TestGenerator/UdpTestGenerator.cs
@@ -24,7 +24,7 @@ namespace TimberWinR.TestGenerator
             NumMessages = 100;
             Port = 6379;
             Host = "localhost";
-            SleepTimeMilliseconds = 10;
+            SleepTimeMilliseconds = 1;
         }
     }
 
@@ -48,16 +48,23 @@ namespace TimberWinR.TestGenerator
             {
                 JObject o = new JObject
                 {
-                    {"Application", "udp-generator"},               
-                    {"Host", hostName},
+                    {"Application", "udp-generator"},  
+                    {"Executable", "VP.Common.SvcFrm.Services.Host, Version=29.7.0.0, Culture=neutral, PublicKeyToken=null"},
+                    {"RenderedMessage", "Responding to RequestSchedule message from 10.1.230.36 with Ack because: PRJ byte array is null."},
+                    {"Team", "Manufacturing Software"},   
+                    {"Host", hostName},                   
                     {"UtcTimestamp", DateTime.UtcNow.ToString("o")},
-                    {"Type", "udp"},                
+                    {"Type", "VP.Fulfillment.Direct.Initialization.LogWrapper"},                
                     {"Message", "Testgenerator udp message " + DateTime.UtcNow.ToString("o")},
                     {"Index", "logstash"}
                 };
                 byte[] sendbuf = Encoding.UTF8.GetBytes(o.ToString());
                 IPEndPoint ep = new IPEndPoint(broadcast, parms.Port);
                 s.SendTo(sendbuf, ep);
+
+                if (i % 1000 == 0)
+                    LogManager.GetCurrentClassLogger().Info("Sent {0} of {1} messages", i, parms.NumMessages);
+
                 Thread.Sleep(parms.SleepTimeMilliseconds);
             }
 

--- a/TimberWinR.TestGenerator/default.json
+++ b/TimberWinR.TestGenerator/default.json
@@ -36,7 +36,7 @@
                     "batch_count": 500,
                     "threads":  2,
                     "host": [
-                        "tstlexiceapp006.vistaprint.svc"
+                        "tstlexiceapp006.mycompany.svc"
                     ]
                 }
             ]

--- a/TimberWinR.TestGenerator/results5.json
+++ b/TimberWinR.TestGenerator/results5.json
@@ -1,0 +1,13 @@
+﻿{
+    "Results": {
+        "Inputs": [           
+            {
+                "udp": {
+                    "test1: message sent count": "[messages] == 10000",
+                    "test2: average cpu": "[avgCpuUsage] <= 30",
+                    "test3: maximum memory": "[maxMemUsage] <= 30"              
+                }
+            }
+        ]
+    }
+}

--- a/TimberWinR.TestGenerator/results5.json
+++ b/TimberWinR.TestGenerator/results5.json
@@ -3,7 +3,7 @@
         "Inputs": [           
             {
                 "udp": {
-                    "test1: message sent count": "[messages] == 10000",
+                    "test1: message sent count": "[messages] == 80000",
                     "test2: average cpu": "[avgCpuUsage] <= 30",
                     "test3: maximum memory": "[maxMemUsage] <= 30"              
                 }

--- a/TimberWinR.TestGenerator/test1-twconfig.json
+++ b/TimberWinR.TestGenerator/test1-twconfig.json
@@ -41,7 +41,7 @@
                     "batch_count": 500,
                     "threads": 1,
                     "host": [
-                        "tstlexiceapp006.vistaprint.svc"
+                        "tstlexiceapp006.mycompany.svc"
                     ]
                 }
             ]

--- a/TimberWinR.TestGenerator/test2-tw.json
+++ b/TimberWinR.TestGenerator/test2-tw.json
@@ -36,7 +36,7 @@
                     "batch_count": 500,
                     "threads":  2,
                     "host": [
-                        "tstlexiceapp006.vistaprint.svc"
+                        "tstlexiceapp006.mycompany.svc"
                     ]
                 }
             ]

--- a/TimberWinR.TestGenerator/test3-tw.json
+++ b/TimberWinR.TestGenerator/test3-tw.json
@@ -41,7 +41,7 @@
                     "batch_count": 500,
                     "threads": 2,
                     "host": [
-                        "tstlexiceapp006.vistaprint.svc"
+                        "tstlexiceapp006.mycompany.svc"
                     ]
                 }
             ]

--- a/TimberWinR.TestGenerator/test4-tw.json
+++ b/TimberWinR.TestGenerator/test4-tw.json
@@ -41,7 +41,7 @@
                     "batch_count": 500,
                     "threads": 2,
                     "host": [
-                        "tstlexiceapp006.vistaprint.svc"
+                        "tstlexiceapp006.mycompany.svc"
                     ]
                 }
             ]

--- a/TimberWinR.TestGenerator/test5-twconfig.json
+++ b/TimberWinR.TestGenerator/test5-twconfig.json
@@ -9,7 +9,7 @@
                         "Environment",
                         "PLANT_TST_TIMBERWINR"
                     ],
-                     "rename": [
+                    "rename": [
                         "Type",
                         "type"
                     ]
@@ -25,16 +25,10 @@
             ]
         },
         "Outputs": {
-            "Redis": [
+            "File": [
                 {
-                    "_comment": "Change the host to your Redis instance",
-                    "port": 6379,
-                    "batch_count": 500,
-                    "interval":  1000,
-                    "threads": 4,
-                    "host": [
-                        "tstlexiceapp006.mycompany.svc"
-                    ]
+                    "format":  "indented",
+                    "file_name": "test5_output.txt"
                 }
             ]
         }

--- a/TimberWinR.TestGenerator/test5-twconfig.json
+++ b/TimberWinR.TestGenerator/test5-twconfig.json
@@ -33,7 +33,7 @@
                     "interval":  1000,
                     "threads": 4,
                     "host": [
-                        "tstlexiceapp006.vistaprint.svc"
+                        "tstlexiceapp006.mycompany.svc"
                     ]
                 }
             ]

--- a/TimberWinR.TestGenerator/test5-twconfig.json
+++ b/TimberWinR.TestGenerator/test5-twconfig.json
@@ -4,7 +4,15 @@
             "Udp": [
                 {
                     "_comment": "Output from NLog",
-                    "port": 5140
+                    "port": 5140,
+                    "add_field": [
+                        "Environment",
+                        "PLANT_TST_TIMBERWINR"
+                    ],
+                     "rename": [
+                        "Type",
+                        "type"
+                    ]
                 }
             ],
             "TailFiles": [
@@ -16,30 +24,14 @@
                 }
             ]
         },
-        "Filters": [
-            {
-                "grok": {
-                    "condition": "\"[EventTypeName]\" == \"Information Event\"",
-                    "match": [
-                        "Text",
-                        ""
-                    ],
-                    "drop": "true"
-                },
-                "json": {
-                    "type": "Win32-TailFile",
-                    "source": "Text",
-                    "promote": "Text"
-                }
-            }
-        ],
         "Outputs": {
             "Redis": [
                 {
                     "_comment": "Change the host to your Redis instance",
                     "port": 6379,
                     "batch_count": 500,
-                    "threads": 1,
+                    "interval":  1000,
+                    "threads": 4,
                     "host": [
                         "tstlexiceapp006.vistaprint.svc"
                     ]

--- a/TimberWinR.TestGenerator/test5.json
+++ b/TimberWinR.TestGenerator/test5.json
@@ -1,0 +1,15 @@
+﻿{
+    "test": "Test 5",
+    "arguments": {
+        "--start":  "",
+        "--testFile": "test5.json",
+        "--testDir": "test5",
+        "--timberWinRConfig": "test5-twconfig.json",
+        "--numMessages": 20000,
+        "--logLevel": "debug",
+        "--udp-host":  "localhost",
+        "--udp": "5140",  
+        "--udp-rate":  5,            
+        "--resultsFile": "results5.json"
+    }
+}

--- a/TimberWinR.TestGenerator/test5.json
+++ b/TimberWinR.TestGenerator/test5.json
@@ -5,11 +5,11 @@
         "--testFile": "test5.json",
         "--testDir": "test5",
         "--timberWinRConfig": "test5-twconfig.json",
-        "--numMessages": 20000,
+        "--numMessages": 80000,
         "--logLevel": "debug",
         "--udp-host":  "localhost",
         "--udp": "5140",  
-        "--udp-rate":  5,            
+        "--udp-rate":  1,            
         "--resultsFile": "results5.json"
     }
 }

--- a/TimberWinR.UnitTests/JsonFilterTests.cs
+++ b/TimberWinR.UnitTests/JsonFilterTests.cs
@@ -77,5 +77,56 @@ namespace TimberWinR.UnitTests
             Assert.IsNull(nostuff);
             Assert.AreEqual(6, jsonInputLine2.Count);            
         }
+
+        [Test]
+        public void TestRenameAndAdds()
+        {
+            JObject jsonInputLine1 = new JObject
+            {               
+                {"type", "Win32-FileLog"},
+                {"ComputerName", "dev.mycompany.net"},
+                {"Text", "{\"log4net:Username\" : \"NT AUTHORITY\",\"Email\":\"james@example.com\",\"Active\":true,\"CreatedDate\":\"2013-01-20T00:00:00Z\",\"Roles\":[\"User\",\"Admin\"]}"}
+            };
+
+
+            string jsonFilter = @"{  
+            ""TimberWinR"":{        
+                ""Filters"":[  
+	                {  
+		            ""json"":{  
+		                ""type"": ""Win32-FileLog"",		               
+                        ""source"": ""Text"",
+                        ""promote"": ""Text"",
+                        ""add_field"":[  
+                            ""test1"",
+                            ""value1"",
+                            ""test2"",
+                            ""value2""
+                        ],       
+                        ""rename"":[  
+                            ""Active"",
+                            ""active"",
+                            ""log4net:Username"",
+                            ""lusername""
+                        ]          
+		            }
+	              }]
+                }
+            }";
+            
+
+            // Positive Tests
+            Configuration c = Configuration.FromString(jsonFilter);
+            Json jf = c.Filters.First() as Json;
+            Assert.IsTrue(jf.Apply(jsonInputLine1));
+
+            Assert.AreEqual("NT AUTHORITY", jsonInputLine1["lusername"].ToString());
+            Assert.AreEqual("True", jsonInputLine1["active"].ToString());
+            Assert.IsNotNull(jsonInputLine1["test1"]);
+            Assert.IsNotNull(jsonInputLine1["test2"]);
+            Assert.AreEqual("value1", jsonInputLine1["test1"].ToString());
+            Assert.AreEqual("value2", jsonInputLine1["test2"].ToString());
+        }
+ 
     }
 }

--- a/TimberWinR.sln
+++ b/TimberWinR.sln
@@ -116,4 +116,7 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 EndGlobal

--- a/TimberWinR/Configuration.cs
+++ b/TimberWinR/Configuration.cs
@@ -58,6 +58,12 @@ namespace TimberWinR
             get { return _stdoutOutputs; }
         }
 
+        private List<FileOutputParameters> _fileOutputs = new List<FileOutputParameters>();
+        public IEnumerable<FileOutputParameters> FileOutputs
+        {
+            get { return _fileOutputs; }
+        }
+
         private List<TcpParameters> _tcps = new List<TcpParameters>();
         public IEnumerable<TcpParameters> Tcps
         {
@@ -265,6 +271,8 @@ namespace TimberWinR
                     c._elasticsearchOutputs.AddRange(x.TimberWinR.Outputs.Elasticsearch.ToList());
                 if (x.TimberWinR.Outputs.Stdout != null)
                     c._stdoutOutputs.AddRange(x.TimberWinR.Outputs.Stdout.ToList());
+                if (x.TimberWinR.Outputs.File != null)
+                    c._fileOutputs.AddRange(x.TimberWinR.Outputs.File.ToList());
             }
 
             if (x.TimberWinR.Filters != null)
@@ -302,6 +310,7 @@ namespace TimberWinR
             _redisOutputs = new List<RedisOutputParameters>();
             _elasticsearchOutputs = new List<ElasticsearchOutputParameters>();
             _stdoutOutputs = new List<StdoutOutputParameters>();
+            _fileOutputs = new List<FileOutputParameters>();
             _tcps = new List<TcpParameters>();
             _udps = new List<UdpParameters>();
         }

--- a/TimberWinR/Filters/JsonFilter.cs
+++ b/TimberWinR/Filters/JsonFilter.cs
@@ -92,9 +92,12 @@ namespace TimberWinR.Parser
 
                     if (Rename != null && Rename.Length > 0)
                     {
-                        string oldName = ExpandField(Rename[0], json);
-                        string newName = ExpandField(Rename[1], json);
-                        RenameProperty(json, oldName, newName);
+                        for (int i = 0; i < Rename.Length; i += 2)
+                        {
+                            string oldName = ExpandField(Rename[i], json);
+                            string newName = ExpandField(Rename[i+1], json);
+                            RenameProperty(json, oldName, newName);
+                        }
                     }
 
                     if (RemoveSource)

--- a/TimberWinR/Inputs/InputListener.cs
+++ b/TimberWinR/Inputs/InputListener.cs
@@ -101,6 +101,34 @@ namespace TimberWinR.Inputs
                 LogManager.GetCurrentClassLogger().Error(ex);
             }          
         }
+       
+        protected void AddOrModify(JObject json, string fieldName, string fieldValue)
+        {
+            if (json[fieldName] == null)
+                json.Add(fieldName, fieldValue);
+            else
+                json[fieldName] = fieldValue;
+        }
+
+        protected void RenameProperty(JObject json, string oldName, string newName)
+        {
+            JToken token = json[oldName];
+            if (token != null)
+            {
+                json.Add(newName, token.DeepClone());
+                json.Remove(oldName);
+            }
+        }
+
+        protected string ExpandField(string fieldName, JObject json)
+        {
+            foreach (var token in json.Children().ToList())
+            {
+                string replaceString = "%{" + token.Path + "}";
+                fieldName = fieldName.Replace(replaceString, json[token.Path].ToString());
+            }
+            return fieldName;
+        }
 
         protected void EnsureRollingCaught()
         {
@@ -127,6 +155,7 @@ namespace TimberWinR.Inputs
                 LogManager.GetCurrentClassLogger().Error(ex);
             }           
         }
+
 
         public virtual void AddDefaultFields(JObject json)
         {

--- a/TimberWinR/Inputs/InputListener.cs
+++ b/TimberWinR/Inputs/InputListener.cs
@@ -44,6 +44,11 @@ namespace TimberWinR.Inputs
                              .ToString();    
         }
 
+        public void SetTypeName(string newType)
+        {
+            _typeName = newType;
+        }
+
         public bool HaveSeenFile(string fileName)
         {
             return Files.Contains(fileName);

--- a/TimberWinR/Inputs/LogsListener.cs
+++ b/TimberWinR/Inputs/LogsListener.cs
@@ -53,6 +53,9 @@ namespace TimberWinR.Inputs
             if (_codecArguments != null && _codecArguments.Type == CodecArguments.CodecType.multiline)
                 _codec = new Multiline(_codecArguments);
 
+            if (!string.IsNullOrEmpty(arguments.Type))
+                SetTypeName(arguments.Type);
+
             _receivedMessages = 0;
             _arguments = arguments;
             _pollingIntervalInSeconds = arguments.Interval;

--- a/TimberWinR/Inputs/TailFileListener.cs
+++ b/TimberWinR/Inputs/TailFileListener.cs
@@ -48,6 +48,9 @@ namespace TimberWinR.Inputs
             if (_codecArguments != null && _codecArguments.Type == CodecArguments.CodecType.multiline)
                 _codec = new Multiline(_codecArguments);
 
+            if (!string.IsNullOrEmpty(arguments.Type))
+                SetTypeName(arguments.Type);
+
             _receivedMessages = 0;
             _arguments = arguments;
             _pollingIntervalInSeconds = arguments.Interval;

--- a/TimberWinR/Manager.cs
+++ b/TimberWinR/Manager.cs
@@ -232,7 +232,7 @@ namespace TimberWinR
 
                 foreach (var tcp in config.Tcps)
                 {
-                    var elistner = new TcpInputListener(cancelToken, tcp.Port);
+                    var elistner = new TcpInputListener(tcp, cancelToken, tcp.Port);
                     Listeners.Add(elistner);
                     foreach (var output in Outputs)
                         output.Connect(elistner);
@@ -240,7 +240,7 @@ namespace TimberWinR
 
                 foreach (var udp in config.Udps)
                 {
-                    var elistner = new UdpInputListener(cancelToken, udp.Port);
+                    var elistner = new UdpInputListener(udp, cancelToken, udp.Port);
                     Listeners.Add(elistner);
                     foreach (var output in Outputs)
                         output.Connect(elistner);

--- a/TimberWinR/Manager.cs
+++ b/TimberWinR/Manager.cs
@@ -190,6 +190,15 @@ namespace TimberWinR
                     }
                 }
 
+                if (config.FileOutputs != null)
+                {
+                    foreach (var ro in config.FileOutputs)
+                    {
+                        var output = new FileOutput(this, ro, cancelToken);
+                        Outputs.Add(output);
+                    }
+                }
+
                 foreach (Parser.IISW3CLogParameters iisw3cConfig in config.IISW3C)
                 {
                     var elistner = new IISW3CInputListener(iisw3cConfig, cancelToken);

--- a/TimberWinR/Outputs/File.cs
+++ b/TimberWinR/Outputs/File.cs
@@ -1,0 +1,140 @@
+﻿using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TimberWinR.Outputs
+{
+    public class FileOutput : OutputSender
+    {
+        private TimberWinR.Manager _manager;
+        private readonly int _interval;
+        private readonly object _locker = new object();
+        private readonly List<JObject> _jsonQueue;
+        private long _sentMessages;     
+        private Parser.FileOutputParameters _arguments;
+        public bool Stop { get; set; }
+
+        public FileOutput(TimberWinR.Manager manager, Parser.FileOutputParameters arguments, CancellationToken cancelToken)
+            : base(cancelToken, "File")
+        {
+            _arguments = arguments;
+            _sentMessages = 0;
+            _manager = manager;
+            _interval = arguments.Interval;
+            _jsonQueue = new List<JObject>();
+
+            var elsThread = new Task(FileSender, cancelToken);
+            elsThread.Start();
+        }
+
+        public override JObject ToJson()
+        {
+            JObject json = new JObject(
+                new JProperty("file-output",
+                    new JObject(
+                        new JProperty("queuedMessageCount", _jsonQueue.Count),
+                        new JProperty("sentMessageCount", _sentMessages))));
+
+            return json;
+        }
+
+        // 
+        // Pull off messages from the Queue, batch them up and send them all across
+        // 
+        private void FileSender()
+        {
+           
+            using (var syncHandle = new ManualResetEventSlim())
+            {
+                var fi = new FileInfo(_arguments.FileName);
+                if (File.Exists(_arguments.FileName))
+                    File.Delete(_arguments.FileName);
+
+                LogManager.GetCurrentClassLogger().Info("File Output Sending To: {0}", fi.FullName);
+       
+                using (StreamWriter sw = File.AppendText(_arguments.FileName))
+                {
+                    // Execute the query
+                    while (!Stop)
+                    {
+                        if (!CancelToken.IsCancellationRequested)
+                        {
+                            try
+                            {
+                                JObject[] messages;
+                                lock (_locker)
+                                {
+                                    messages = _jsonQueue.Take(_jsonQueue.Count).ToArray();
+                                    _jsonQueue.RemoveRange(0, messages.Length);
+                                }
+
+                                if (messages.Length > 0)
+                                {
+                                    try
+                                    {
+                                        foreach (JObject obj in messages)
+                                        {                                           
+                                            sw.WriteLine(obj.ToString(_arguments.ToFormat()));                                        
+                                            _sentMessages++;
+                                        }
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        LogManager.GetCurrentClassLogger().Error(ex);
+                                    }
+                                }
+                                if (!Stop)
+                                    syncHandle.Wait(TimeSpan.FromMilliseconds(_interval), CancelToken);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                break;
+                            }
+                            catch (Exception)
+                            {
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        protected override void MessageReceivedHandler(Newtonsoft.Json.Linq.JObject jsonMessage)
+        {
+            if (_manager.Config.Filters != null)
+            {
+                if (ApplyFilters(jsonMessage))
+                    return;
+            }
+
+            var message = jsonMessage.ToString();
+   
+            lock (_locker)
+            {
+                _jsonQueue.Add(jsonMessage);
+            }
+        }
+
+        private bool ApplyFilters(JObject json)
+        {
+            bool drop = false;
+
+            foreach (var filter in _manager.Config.Filters)
+            {
+                if (!filter.Apply(json))
+                    drop = true;
+            }
+
+            return drop;
+        }
+
+    }
+}
+

--- a/TimberWinR/Parser.cs
+++ b/TimberWinR/Parser.cs
@@ -12,6 +12,7 @@ using Microsoft.SqlServer.Server;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NLog;
+using NLog.Config;
 using TimberWinR.Outputs;
 using System.CodeDom.Compiler;
 
@@ -42,11 +43,9 @@ namespace TimberWinR.Parser
         {
             JToken token = json[oldName];
             if (token != null)
-            {
+            {                
+                json.Add(newName, token.DeepClone());
                 json.Remove(oldName);
-                JToken newToken = json[newName];
-                if (newToken == null)
-                    json.Add(newName, token);
             }
         }
 
@@ -269,7 +268,7 @@ namespace TimberWinR.Parser
         public string Type { get; set; }
 
         [JsonProperty(PropertyName = "codec")]
-        public CodecArguments CodecArguments { get; set; }       
+        public CodecArguments CodecArguments { get; set; }
 
         [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }
@@ -281,7 +280,7 @@ namespace TimberWinR.Parser
         public int Rate { get; set; }
 
         public void Validate()
-        {                      
+        {
         }
 
         public GeneratorParameters()
@@ -336,9 +335,9 @@ namespace TimberWinR.Parser
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
         [JsonProperty(PropertyName = "location")]
-        public string Location { get; set; }       
+        public string Location { get; set; }
         [JsonProperty(PropertyName = "recurse")]
-        public int Recurse { get; set; }        
+        public int Recurse { get; set; }
         [JsonProperty(PropertyName = "fields")]
         public List<Field> Fields { get; set; }
         [JsonProperty(PropertyName = "interval")]
@@ -403,15 +402,21 @@ namespace TimberWinR.Parser
     {
         [JsonProperty(PropertyName = "port")]
         public int Port { get; set; }
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+        [JsonProperty("add_field")]
+        public string[] AddFields { get; set; }
+        [JsonProperty("rename")]
+        public string[] Renames { get; set; }
 
         public TcpParameters()
         {
             Port = 5140;
+            Type = "Win32-Tcp";
         }
 
         public void Validate()
         {
-
         }
     }
 
@@ -420,15 +425,21 @@ namespace TimberWinR.Parser
     {
         [JsonProperty(PropertyName = "port")]
         public int Port { get; set; }
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+        [JsonProperty("add_field")]
+        public string[] AddFields { get; set; }
+        [JsonProperty("rename")]
+        public string[] Renames { get; set; }
 
         public UdpParameters()
         {
             Port = 5142;
+            Type = "Win32-Udp";
         }
 
         public void Validate()
         {
-
         }
     }
     public class W3CLogParameters : IValidateSchema
@@ -557,9 +568,9 @@ namespace TimberWinR.Parser
         [JsonProperty(PropertyName = "max_queue_size")]
         public int MaxQueueSize { get; set; }
         [JsonProperty(PropertyName = "queue_overflow_discard_oldest")]
-        public bool QueueOverflowDiscardOldest { get; set; }        
+        public bool QueueOverflowDiscardOldest { get; set; }
         [JsonProperty(PropertyName = "enable_ping")]
-        public bool EnablePing { get; set; }      
+        public bool EnablePing { get; set; }
         [JsonProperty(PropertyName = "ping_timeout")]
         public int PingTimeout { get; set; }
 
@@ -650,7 +661,6 @@ namespace TimberWinR.Parser
             Host = new string[] { "localhost" };
             Timeout = 10000;
             BatchCount = 200;
-            MaxBatchCount = BatchCount*10;
             NumThreads = 1;
             Interval = 5000;
             QueueOverflowDiscardOldest = true;
@@ -755,7 +765,7 @@ namespace TimberWinR.Parser
 
         public override void Validate()
         {
-            if (Match == null || Match.Length != 2)
+            if (Match == null || Match.Length % 2 != 0)
                 throw new GrokFilterException();
 
             if (AddTag != null && AddTag.Length % 2 != 0)
@@ -896,7 +906,7 @@ namespace TimberWinR.Parser
         }
     }
 
-   
+
     public partial class Json : LogstashFilter
     {
         public class JsonMissingSourceException : Exception
@@ -980,7 +990,7 @@ namespace TimberWinR.Parser
 
         [JsonProperty("grokFilters")]
         public Grok[] Groks { get; set; }
-      
+
         [JsonProperty("mutateFilters")]
         public Mutate[] Mutates { get; set; }
 
@@ -991,7 +1001,7 @@ namespace TimberWinR.Parser
         public Json[] Jsons { get; set; }
 
         [JsonProperty("geoipFilters")]
-        public GeoIP[] GeoIPs { get; set; }    
+        public GeoIP[] GeoIPs { get; set; }
     }
 
     public class TimberWinR

--- a/TimberWinR/Parser.cs
+++ b/TimberWinR/Parser.cs
@@ -43,7 +43,7 @@ namespace TimberWinR.Parser
         {
             JToken token = json[oldName];
             if (token != null)
-            {                
+            {
                 json.Add(newName, token.DeepClone());
                 json.Remove(oldName);
             }
@@ -679,6 +679,43 @@ namespace TimberWinR.Parser
         }
     }
 
+    public class FileOutputParameters
+    {
+        public enum FormatKind
+        {
+            none, indented
+        };
+
+        [JsonProperty(PropertyName = "interval")]
+        public int Interval { get; set; }
+
+        [JsonProperty(PropertyName = "file_name")]
+        public string FileName { get; set; }
+
+        [JsonProperty(PropertyName = "format")]
+        public FormatKind Format { get; set; }
+
+        public FileOutputParameters()
+        {
+            Format = FormatKind.none;            
+            Interval = 1000;
+            FileName = "timberwinr.out";
+        }
+
+        public Newtonsoft.Json.Formatting ToFormat()
+        {
+            switch (Format)
+            {
+                case FormatKind.indented:
+                    return Newtonsoft.Json.Formatting.Indented;
+
+                case FormatKind.none:
+                default:
+                    return Newtonsoft.Json.Formatting.None;
+            }
+        }
+    }
+
     public class OutputTargets
     {
         [JsonProperty("Redis")]
@@ -689,6 +726,9 @@ namespace TimberWinR.Parser
 
         [JsonProperty("Stdout")]
         public StdoutOutputParameters[] Stdout { get; set; }
+
+        [JsonProperty("File")]
+        public FileOutputParameters[] File { get; set; }
     }
 
     public class InputSources

--- a/TimberWinR/Parser.cs
+++ b/TimberWinR/Parser.cs
@@ -333,6 +333,8 @@ namespace TimberWinR.Parser
 
     public class TailFileArguments : IValidateSchema
     {
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
         [JsonProperty(PropertyName = "location")]
         public string Location { get; set; }       
         [JsonProperty(PropertyName = "recurse")]
@@ -363,6 +365,8 @@ namespace TimberWinR.Parser
 
     public class LogParameters : IValidateSchema
     {
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
         [JsonProperty(PropertyName = "location")]
         public string Location { get; set; }
         [JsonProperty(PropertyName = "iCodepage")]

--- a/TimberWinR/ReleaseNotes.md
+++ b/TimberWinR/ReleaseNotes.md
@@ -8,6 +8,7 @@ Version / Date
 2. Fixed potential non-thread safe when renaming properties
 3. Added add_field, rename support to Udp/Tcp Input Listeners
 4. Fixed issue with multiple renames (was previously only renaming the first one)
+5. Added File outputter for testing.
 
 ### 1.3.24.0 - 2015-04-29
 1. Fixed potential bug in TailFiles when tailing log files which are partially flushed

--- a/TimberWinR/ReleaseNotes.md
+++ b/TimberWinR/ReleaseNotes.md
@@ -3,6 +3,12 @@
 A Native Windows to Redis/Elasticsearch Logstash Agent which runs as a service.
 
 Version / Date
+### 1.3.25.0 - 2015-04-30
+1. Fixed Issue [#49](https://github.com/Cimpress-MCP/TimberWinR/issues/49)
+2. Fixed potential non-thread safe when renaming properties
+3. Added add_field, rename support to Udp/Tcp Input Listeners
+4. Fixed issue with multiple renames (was previousy only renaming the first one)
+
 ### 1.3.24.0 - 2015-04-29
 1. Fixed potential bug in TailFiles when tailing log files which are partially flushed
    to disk, it now will not process the line until the \r\n has been seen.

--- a/TimberWinR/ReleaseNotes.md
+++ b/TimberWinR/ReleaseNotes.md
@@ -7,7 +7,7 @@ Version / Date
 1. Fixed Issue [#49](https://github.com/Cimpress-MCP/TimberWinR/issues/49)
 2. Fixed potential non-thread safe when renaming properties
 3. Added add_field, rename support to Udp/Tcp Input Listeners
-4. Fixed issue with multiple renames (was previousy only renaming the first one)
+4. Fixed issue with multiple renames (was previously only renaming the first one)
 
 ### 1.3.24.0 - 2015-04-29
 1. Fixed potential bug in TailFiles when tailing log files which are partially flushed

--- a/TimberWinR/TimberWinR.csproj
+++ b/TimberWinR/TimberWinR.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Outputs\Elasticsearch.cs" />
     <Compile Include="Outputs\OutputSender.cs" />
     <Compile Include="Outputs\Redis.cs" />
+    <Compile Include="Outputs\File.cs" />
     <Compile Include="Outputs\Stdout.cs" />
     <Compile Include="Parser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -141,6 +142,7 @@
     <None Include="mdocs\Filters.md" />
     <None Include="mdocs\GeoIPFilter.md" />
     <None Include="mdocs\Generator.md" />
+    <None Include="mdocs\FileOutput.md" />
     <None Include="mdocs\TailFiles.md" />
     <None Include="mdocs\UdpInput.md" />
     <None Include="mdocs\W3CInput.md" />

--- a/TimberWinR/mdocs/FileOutput.md
+++ b/TimberWinR/mdocs/FileOutput.md
@@ -1,0 +1,27 @@
+# Output: File
+
+The File output passes on data into a text file.
+
+## Parameters
+The following parameters are allowed when configuring the File output.
+
+| Parameter     |   Type   |  Description                                                | Details               |  Default |
+| :-------------|:---------|:------------------------------------------------------------| :---------------------------  | :-- |
+| *interval*    | integer  | Interval in milliseconds to sleep before appending data       | Interval      | 1000 |
+| *file_name*   | string   | Name of the file to be created                              |               | timberwinr.out |
+
+Example Input:
+```json
+{
+    "TimberWinR": {
+        "Outputs": {
+            "File": [
+               { 
+                    "file_name":  "foo.out",   
+                    "interval": 1000                   
+                }
+            ]
+		}
+	}
+}
+```

--- a/TimberWinR/mdocs/GrokFilter.md
+++ b/TimberWinR/mdocs/GrokFilter.md
@@ -26,14 +26,14 @@ The following operations are allowed when mutating a field.
 
 | Operation       |     Type        | Description                                                            
 | :---------------|:----------------|:-----------------------------------------------------------------------|
-| *type*          | property:string |Type to which this filter applyes, if empty, applies to all types.
-| *condition*     | property:string |C# expression
-| *rename*        | property:array  |Rename one or more fields                                       
-| *match*         | property:string |Required field must match before any subsequent grok operations are executed.
 | *add_field*     | property:array  |If the filter is successful, add an arbitrary field to this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.  This property must be specified in pairs.                                    
-| *remove_field*  | property:array  |If the filter is successful, remove arbitrary fields from this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.                                
 | *add_tag*       | property:array  |If the filter is successful, add an arbitrary tag to this event.  Tag names can be dynamic and include parts of the event using the %{field} syntax.                                  
+| *condition*     | property:string |C# expression
+| *match*         | property:array  |Required field must match (any) before any subsequent grok operations are executed.
+| *remove_field*  | property:array  |If the filter is successful, remove arbitrary fields from this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.                                
 | *remove_tag*    | property:array  |If the filter is successful, remove arbitrary tags from this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.                          
+| *rename*        | property:array  |Rename one or more fields                                       
+| *type*          | property:string |Type to which this filter applyes, if empty, applies to all types.
 
 ## Operation Details
 ### match 
@@ -67,6 +67,28 @@ Given this configuration
     }     
   ]
 ```
+
+Given this configuration
+```json
+  "Filters": [     
+    {
+	   "grok": {
+           "matches": [
+               "message",
+               "%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}"
+           ],
+           "add_tag": [               
+               "http_log"
+           ],
+           "add_field": [
+               "verb", "%{method}"
+           ]
+        }           
+    }     
+  ]
+```
+
+
 And if the message matches, then 6 fields would be added to the event:
  1. client=55.3.244.1
  2. method=GET

--- a/TimberWinR/mdocs/JsonFilter.md
+++ b/TimberWinR/mdocs/JsonFilter.md
@@ -7,25 +7,27 @@ The following operations are allowed when mutating a field.
 
 | Operation       |     Type        | Description                                                            
 | :---------------|:----------------|:-----------------------------------------------------------------------|
-| *type*          | property:string |Type to which this filter applies, if empty, applies to all types.
-| *condition*     | property:string |C# expression, if the expression is true, continue, otherwise, ignore
-| *remove_source* | property:bool   |If true, the source property is removed, default: true
-| *source*        | property:string |Required field indicates which field contains the Json to be parsed
-| *promote*       | property:string |If supplied any properties named *promote* will be promoted to top-level
-| *target*        | property:string |If suppled, the parsed json will be contained underneath a propery named *target*
 | *add_field*     | property:array  |If the filter is successful, add an arbitrary field to this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.  This property must be specified in pairs.                                    
-| *remove_field*  | property:array  |If the filter is successful, remove arbitrary fields from this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.                                
 | *add_tag*       | property:array  |If the filter is successful, add an arbitrary tag to this event.  Tag names can be dynamic and include parts of the event using the %{field} syntax.                                  
+| *condition*     | property:string |C# expression, if the expression is true, continue, otherwise, ignore
+| *promote*       | property:string |If supplied any properties named *promote* will be promoted to top-level
+| *remove_field*  | property:array  |If the filter is successful, remove arbitrary fields from this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.                                
 | *remove_tag*    | property:array  |If the filter is successful, remove arbitrary tags from this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.                          
+| *remove_source* | property:bool   |If true, the source property is removed, default: true
+| *rename*        | property:array  |Rename one or more fields                                       
+| *source*        | property:string |Required field indicates which field contains the Json to be parsed
+| *target*        | property:string |If suppled, the parsed json will be contained underneath a propery named *target*
+| *type*          | property:string |Type to which this filter applies, if empty, applies to all types.
 
 ## Operation Details
 ### source 
-The match field is required, the first argument is the field to inspect, and compare to the expression specified by the second
-argument.  In the below example, the message is spected to be something like this from a fictional sample log:
+The source field is required, and indicates what Field contains the target Json, In the
+below example, the [Logs](https://github.com/Cimpress-MCP/TimberWinR/blob/master/TimberWinR/mdocs/Logs.md) input produces a Text field, 
+which contains a line to be parsed as Json.
 
 Given this input configuration:
 
-Lets assume that a newline such as the following is appended to foo.jlog:
+Lets assume that a new line such as the following is appended to foo.jlog:, this would end up being the Text field
 ```
    {"Email":"james@example.com","Active":true,"CreatedDate":"2013-01-20T00:00:00Z","Roles":["User","Admin"]}
 ```
@@ -54,7 +56,7 @@ Lets assume that a newline such as the following is appended to foo.jlog:
         }       
 ```
 
-In the above example, the file foo.jlog is being tailed, and when a newline is appended, it is assumed
+In the above example, the file foo.jlog is being tailed, and when a new line is appended, it is assumed
 to be Json and is parsed from the Text field, the parsed Json is then inserted underneath a property *stuff*
 
 The resulting output would be:
@@ -84,8 +86,8 @@ The fields must be in pairs with oldname first and newname second.
         "target": "stuff",
         "source": "Text",
         "rename": [
-            "Text",
-            "Data"
+            "level",
+            "Level"
         ]                   
      } 
    }     
@@ -96,7 +98,9 @@ The fields must be in pairs with fieldName first and value second.
 ```json
   "Filters": [     
     {
-		"json": {      			
+		"json": {  
+          "type":  "Win32-FileLog",       
+          "source": "Text",   			
 			"add_field": [
               "ComputerName", "Host",
               "Username", "%{SID}"				         
@@ -112,7 +116,9 @@ Remove the fields.  More than one field can be specified at a time.
   "Filters": [     
     {
 		"json": {      			
-			"remove_tag": [             
+          "type":  "Win32-FileLog",       
+          "source": "Text",   			
+			"remove_field": [             
              "static_tag1",
              "Computer_%{Host}"
 			]
@@ -128,6 +134,8 @@ Adds the tag(s) to the tag array.
   "Filters": [     
     {
 		"json": {      			
+          "type":  "Win32-FileLog",       
+          "source": "Text",   			
 			"add_tag": [
                "foo_%{Host}",
 			   "static_tag1"      
@@ -143,6 +151,8 @@ Remove the tag(s) to the tag array.  More than one tag can be specified at a tim
   "Filters": [     
     {
 		"json": {      			
+          "type":  "Win32-FileLog",       
+          "source": "Text",   			
 			"remove_tag": [             
              "static_tag1",
              "Username"

--- a/TimberWinR/mdocs/Logs.md
+++ b/TimberWinR/mdocs/Logs.md
@@ -7,11 +7,12 @@ The following parameters are allowed when configuring WindowsEvents.
 
 | Parameter         |     Type       |  Description                                                             | Details               |  Default |
 | :---------------- |:---------------| :----------------------------------------------------------------------- | :---------------------------  | :-- |
+| *iCodepage*       | integer |Codepage of the text file.                                              | 0 is the system codepage, -1 is UNICODE.                         | 0  |
 | *location*        | string  |Location of file(s) to monitor                                           | Path to text file(s) including wildcards. |     |
 | *logSource*       | string  |Source name                                  | Used for conditions |     |
 | *recurse*         | integer |Max subdirectory recursion level.                                       | 0 disables subdirectory recursion; -1 enables unlimited recursion. | 0 |
 | *splitLongLines*  | boolean |Behavior when event messages or event category names cannot be resolved. |When a text line is longer than 128K characters, the format truncates the line and either discards the remaining of the line (when this parameter is set to "false"), or processes the remainder of the line as a new line (when this parameter is set to "true").| false |
-| *iCodepage*       | integer |Codepage of the text file.                                              | 0 is the system codepage, -1 is UNICODE.                         | 0  |
+| *type*            | string  |Typename for this Input                                         |  |  Win32-FileLog  |
 | [codec](https://github.com/Cimpress-MCP/TimberWinR/blob/master/TimberWinR/mdocs/Codec.md)  | object | Codec to use  |
 
 Example Input: Monitors all files (recursively) located at C:\Logs1\ matching *.log as a pattern.  I.e. C:\Logs1\foo.log, C:\Logs1\Subdir\Log2.log, etc.
@@ -39,3 +40,4 @@ After a successful parse of an event, the following fields are added:
 | LogFilename | STRING |Full path of the file containing this line | 
 | Index | INTEGER | Line number |
 | Text | STRING | Text line content  |
+| type | STRING | Win32-FileLog |

--- a/TimberWinR/mdocs/RedisOutput.md
+++ b/TimberWinR/mdocs/RedisOutput.md
@@ -7,15 +7,15 @@ The following parameters are allowed when configuring the Redis output.
 
 | Parameter     |   Type   |  Description                                                | Details               |  Default |
 | :-------------|:---------|:------------------------------------------------------------| :---------------------------  | :-- |
-| *threads*     | string   | Location of log files(s) to monitor                         | Number of worker theads to send messages | 1 |
 | *batch_count* | integer  | Sent as a single message                         | Number of messages to aggregate | 200 |
-| *max_batch_count* | integer  | Dynamically adjusted count maximum                      | Increases over time | batch_count*10 |
-| *interval*    | integer  | Interval in milliseconds to sleep during batch sends        | Interval      | 5000 |
+| *host*        | string | The hostname(s) of your Redis server(s) | IP or DNS name |  |
 | *index*       | string   | The name of the redis list                                  | logstash index name | logstash |
-| *host*        | [string] | The hostname(s) of your Redis server(s) | IP or DNS name |  |
-| *port*        | integer  | Redis port number                                           | This port must be open  | 6379  |
+| *interval*    | integer  | Interval in milliseconds to sleep during batch sends        | Interval      | 5000 |
+| *max_batch_count* | integer  | Dynamically adjusted count maximum                      | Increases over time | batch_count * 10 |
 | *max_queue_size* | integer  | Maximum redis queue depth       |  | 50000 |
+| *port*        | integer  | Redis port number                                           | This port must be open  | 6379  |
 | *queue_overflow_discard_oldest* | bool  | If true, discard oldest messages when max_queue_size reached otherwise discard newest |  | true |
+| *threads*     | string   | Location of log files(s) to monitor                         | Number of worker theads to send messages | 1 |
 
 Example Input:
 ```json

--- a/TimberWinR/mdocs/TailFiles.md
+++ b/TimberWinR/mdocs/TailFiles.md
@@ -8,6 +8,7 @@ The following parameters are allowed when configuring WindowsEvents.
 
 | Parameter         |     Type       |  Description                                                             | Details               |  Default |
 | :---------------- |:---------------| :----------------------------------------------------------------------- | :---------------------------  | :-- |
+| *type*            | string  |Typename for this Input                                         |  |  Win32-TailLog  |
 | *location*        | string  |Location of file(s) to monitor                                           | Path to text file(s) including wildcards. |     |
 | *logSource*       | string  |Source name                                  | Used for conditions |     |
 | *recurse*         | integer |Max subdirectory recursion level.                                       | 0 disables subdirectory recursion; -1 enables unlimited recursion. | 0 |
@@ -39,3 +40,4 @@ After a successful parse of an event, the following fields are added:
 | LogFilename | STRING |Full path of the file containing this line | 
 | Index | INTEGER | Line number |
 | Text | STRING | Text line content  |
+| type | STRING | Win32-TailLog |

--- a/TimberWinR/mdocs/TcpInput.md
+++ b/TimberWinR/mdocs/TcpInput.md
@@ -5,9 +5,12 @@ The Tcp input will open a port and listen for properly formatted JSON and will f
 ## Parameters
 The following parameters are allowed when configuring the Tcp input.
 
-| Parameter         |     Type       |  Description                                                             | Details               |  Default |
-| :---------------- |:---------------| :----------------------------------------------------------------------- | :---------------------------  | :-- |
-| *port*        | integer  |Port number to open        | Must be an available port |     |
+| Parameter         |     Type         |  Description                                                             | Details               |  Default |
+| :---------------- |:-----------------| :----------------------------------------------------------------------- | :---------------------------  | :-- |
+| *add_field*       | property:array   |Add field(s) to this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.  This property must be specified in pairs.  |     |
+| *port*            | integer          |Port number to open        | Must be an available port |     |
+| *rename*          | property:array   |Rename one or more fields  |  |  |                             
+| *type*            | string           |Typename for this Input    |  |  Win32-Tcp  |
 
 Example Input: Listen on Port 5140
 

--- a/TimberWinR/mdocs/UdpInput.md
+++ b/TimberWinR/mdocs/UdpInput.md
@@ -7,7 +7,10 @@ The following parameters are allowed when configuring the Udp input.
 
 | Parameter         |     Type       |  Description                                                             | Details               |  Default |
 | :---------------- |:---------------| :----------------------------------------------------------------------- | :---------------------------  | :-- |
-| *port*        | integer  |Port number to open        | Must be an available port |     |
+| *add_field*       | property:array   |Add field(s) to this event.  Field names can be dynamic and include parts of the event using the %{field} syntax.  This property must be specified in pairs.  |     |
+| *port*            | integer  |Port number to open        | Must be an available port |     |
+| *rename*          | property:array   |Rename one or more fields  |  |  |                             
+| *type*            | string   |Typename for this Input                                         |  |  Win32-Udp  |
 
 Example Input: Listen on Port 5142
 


### PR DESCRIPTION
1. Fixed Issue [#49](https://github.com/Cimpress-MCP/TimberWinR/issues/49)
2. Fixed potential non-thread safe when renaming properties
3. Added add_field, rename support to Udp/Tcp Input Listeners
4. Fixed issue with multiple renames (was previously only renaming the first one)

@ethergreg please review.