### PR TITLE
Added support for HTTPS authentication to Found clusters

### DIFF
--- a/TimberWinR/Parser.cs
+++ b/TimberWinR/Parser.cs
@@ -625,8 +625,16 @@ namespace TimberWinR.Parser
     }
 
 
-    public class ElasticsearchOutputParameters
+    public class ElasticsearchOutputParameters : IValidateSchema
     {
+        public class ElasticsearchBasicAuthException : Exception
+        {
+            public ElasticsearchBasicAuthException()
+                : base("Elasticsearch 'username' and 'password' properties must be set when SSL is enabled.")
+            {
+            }
+        }
+
         const string IndexDatePattern = "(%\\{(?<format>[^\\}]+)\\})";
 
         [JsonProperty(PropertyName = "host")]
@@ -635,6 +643,12 @@ namespace TimberWinR.Parser
         public string Index { get; set; }
         [JsonProperty(PropertyName = "port")]
         public int Port { get; set; }
+        [JsonProperty(PropertyName = "ssl")]
+        public bool Ssl { get; set; }
+        [JsonProperty(PropertyName = "username")]
+        public string Username { get; set; }
+        [JsonProperty(PropertyName = "password")]
+        public string Password { get; set; }
         [JsonProperty(PropertyName = "timeout")]
         public int Timeout { get; set; }
         [JsonProperty(PropertyName = "threads")]
@@ -662,6 +676,9 @@ namespace TimberWinR.Parser
             IdleFlushTimeInSeconds = 10;
             Protocol = "http";
             Port = 9200;
+            Ssl = false;
+            Username = string.Empty;
+            Password = string.Empty;
             Index = "";
             Host = new string[] { "localhost" };
             Timeout = 10000;
@@ -711,6 +728,11 @@ namespace TimberWinR.Parser
             return typeName;
         }
 
+        public void Validate()
+        {
+            if (Ssl && (string.IsNullOrWhiteSpace(Username) || string.IsNullOrWhiteSpace(Password)))
+                throw new ElasticsearchBasicAuthException();
+        }
     }
 
     public class RedisOutputParameters

--- a/TimberWinR/mdocs/ElasticsearchOutput.md
+++ b/TimberWinR/mdocs/ElasticsearchOutput.md
@@ -14,6 +14,9 @@ The following parameters are allowed when configuring the Elasticsearch output.
 | *interval*                      | integer  | Interval in milliseconds to sleep during batch sends        | Interval       | 5000 |
 | *max_queue_size*                | integer  | Maximum Elasticsearch queue depth       |  | 50000 |
 | *port*                          | integer  | Elasticsearch port number                                   | This port must be open  | 9200  |
+| *ssl*                           | bool  | If true, use an HTTPS connection to Elasticsearch. See [this page] (https://www.elastic.co/guide/en/found/current/elk-and-found.html#_using_logstash) for a configuration example. | *username* and *password* are also required for HTTPS connections. | false |
+| *username*                      | string | Username for Elasticsearch credentials. | Required for HTTPS connection. | |
+| *password*                      | string | Password for Elasticsearch credentials. | Required for HTTPS connection. | |
 | *queue_overflow_discard_oldest* | bool  | If true, discard oldest messages when max_queue_size reached otherwise discard newest |  | true |
 | *threads*                       | [string]    | Number of Threads                         | Number of worker threads processing messages | 1 |
 | *enable_ping* | bool  | If true, pings the server to test for keep alive |  | false |


### PR DESCRIPTION
Elasticsearch's newly acquired found.io hosted clusters require HTTPS basic authentication in order to feed the index.

This feature branch adds optional support for HTTPS according to https://www.elastic.co/guide/en/found/current/elk-and-found.html#_using_logstash

It all boils down to constructing a different URI for HTTPS mode vs. regular HTTP mode.

When SSL is true, a non-empty username and password are required to authenticate against an Elasticsearch cluster.

---

This is my first pull request to this repo, so hopefully I followed the coding style and patterns.
All the code I added is under test, and I updated the docs.
Let me know if there is something I should change.

Cheers,
Doug